### PR TITLE
Create annotation actions sidebar

### DIFF
--- a/src/components/annotation/AnnotationTool.css
+++ b/src/components/annotation/AnnotationTool.css
@@ -35,5 +35,21 @@
 }
 
 
+.content-area {
+  display: flex;
+  flex: 1;
+}
+
+.canvas-wrapper {
+  flex: 1;
+  position: relative;
+}
+
+.action-sidebar {
+  width: 240px;
+  height: 100%;
+  background-color: #2c2c4680;
+}
+
 
 

--- a/src/components/annotation/AnnotationTool.tsx
+++ b/src/components/annotation/AnnotationTool.tsx
@@ -5,9 +5,7 @@ import Canvas from './components/Canvas';
 import LabelPanel from './LabelPanel';
 import AnnotationControls from './components/AnnotationControl';
 import { useLocation } from 'react-router-dom';
-import ApproveButton from './components/ApproveButton';
-import MarkAsNullButton from './components/MarkAsNullButton';
-import DeleteButton from './components/DeteteButton';
+import ActionSidebar from './components/ActionSidebar';
 import './AnnotationTool.css';
 
 // interface ImageResponse {
@@ -64,9 +62,6 @@ const AnnotationTool = () => {
           onPrevious={handlePrevious}
           onNext={handleNext}
         />
-        <DeleteButton currentImage={image} goToNextImage={handleNext}/>
-        <ApproveButton currentImage={image} goToNextImage={handleNext}/>
-        <MarkAsNullButton currentImage={image} goToNextImage={handleNext}/>
         <div className="annotation-container">
           <div className="annotation-sidebar">
             <ToolBar />
@@ -75,7 +70,10 @@ const AnnotationTool = () => {
           {totalImages === 0? (
             <p>No Image Found</p>
           ) : (
-            <Canvas image={image}/>
+            <div className='content-area'>
+             <Canvas image={image}/>
+             <ActionSidebar currentImage={image} goToNextImage={handleNext} />
+            </div>
           )}
         </div>
       </div>

--- a/src/components/annotation/components/ActionSidebar.tsx
+++ b/src/components/annotation/components/ActionSidebar.tsx
@@ -1,0 +1,47 @@
+
+import React from 'react';
+import { useAnnotation } from '@/contexts/AnnotationContext';
+import ApproveButton from './ApproveButton';
+import DeleteButton from './DeleteButton';
+import MarkAsNullButton from './MarkAsNullButton';
+
+interface Image {
+  image_id: string;
+  project_id: string;
+  url: string;
+}
+
+interface ActionSidebarProps {
+  currentImage: Image;
+  goToNextImage: () => void;
+}
+
+const ActionSidebar:React.FC<ActionSidebarProps> = ({ currentImage, goToNextImage }) => {
+  const { boxes } = useAnnotation();
+
+  return (
+    <div className="action-sidebar">
+      <div className="p-4 border-l border-border bg-card h-full">
+        <h2 className="text-lg font-semibold mb-6 text-white">Actions</h2>
+        
+        <div className="space-y-4">
+          <ApproveButton currentImage={currentImage} goToNextImage={goToNextImage} className="w-full" />
+          <DeleteButton currentImage={currentImage} goToNextImage={goToNextImage} className="w-full" />
+          <MarkAsNullButton currentImage={currentImage} goToNextImage={goToNextImage} className="w-full bg-red-400 text-white" />
+        </div>
+        
+        <div className="mt-8">
+          <h3 className="text-sm font-medium text-muted-foreground text-white mb-2">Image Info</h3>
+          <p className="text-sm truncate text-white">{currentImage.image_id}</p>
+        </div>
+        
+        <div className="mt-4">
+          <h3 className="text-sm font-medium text-muted-foreground mb-2 text-white">Annotations</h3>
+          <p className="text-sm text-white">{boxes.length} bounding boxes</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ActionSidebar;

--- a/src/components/annotation/components/ApproveButton.tsx
+++ b/src/components/annotation/components/ApproveButton.tsx
@@ -14,9 +14,10 @@ interface Image {
   interface ApproveButtonProps {
     currentImage: Image;
     goToNextImage: () => void;
+    className?: string;
   }
 
-const ApproveButton:React.FC<ApproveButtonProps> = ( {currentImage, goToNextImage} ) => {
+const ApproveButton:React.FC<ApproveButtonProps> = ( {currentImage, goToNextImage, className} ) => {
   const { approveImage, isApproving } = useImageApproval();
 //   const { currentImage, goToNextImage } = useImage();
   const { boxes, setBoxes, setSelectedBox } = useAnnotation();
@@ -58,7 +59,7 @@ const ApproveButton:React.FC<ApproveButtonProps> = ( {currentImage, goToNextImag
     <Button 
       onClick={handleApprove} 
       disabled={isApproving}
-      className="absolute top-4 right-4 z-10"
+      className={className}
       variant="default"
     >
       <CheckCircle className="mr-2 h-4 w-4" />

--- a/src/components/annotation/components/DeleteButton.tsx
+++ b/src/components/annotation/components/DeleteButton.tsx
@@ -14,9 +14,10 @@ interface Image {
 interface DeleteButtonProps {
   currentImage: Image;
   goToNextImage: () => void;
+  className?: string;
 }
 
-const DeleteButton:React.FC<DeleteButtonProps> = ( {currentImage, goToNextImage} ) => {
+const DeleteButton:React.FC<DeleteButtonProps> = ( {currentImage, goToNextImage, className} ) => {
   const { deleteImage, isDeleting } = useImageDeletion();
 
   const handleDelete = async () => {
@@ -53,7 +54,7 @@ const DeleteButton:React.FC<DeleteButtonProps> = ( {currentImage, goToNextImage}
     <Button 
       onClick={handleDelete} 
       disabled={isDeleting}
-      className="absolute bottom-24 right-4 z-10"
+      className={className}
       variant="destructive"
     >
       <Trash2 className="mr-2 h-4 w-4" />

--- a/src/components/annotation/components/MarkAsNullButton.tsx
+++ b/src/components/annotation/components/MarkAsNullButton.tsx
@@ -14,9 +14,10 @@ interface Image {
   interface MarkAsNullButtonProps {
     currentImage: Image;
     goToNextImage: () => void;
+    className?: string;
   }
 
-const MarkAsNullButton:React.FC<MarkAsNullButtonProps> = ( {currentImage, goToNextImage} ) => {
+const MarkAsNullButton:React.FC<MarkAsNullButtonProps> = ( {currentImage, goToNextImage, className} ) => {
   const { markImageAsNull, isMarkingAsNull } = useMarkImageAsNull();
 //   const { currentImage, goToNextImage } = useImage();
   const { boxes, setBoxes, setSelectedBox } = useAnnotation();
@@ -48,7 +49,7 @@ const MarkAsNullButton:React.FC<MarkAsNullButtonProps> = ( {currentImage, goToNe
     <Button 
       onClick={handleMarkAsNull} 
       disabled={isMarkingAsNull}
-      className="absolute bottom-12 right-4 z-10 bg-red-400 text-white"
+      className={className}
     >
       <Ban className="mr-1 h-4 w-4 bg-red-400" />
       {isMarkingAsNull ? "Marking ..." : "Mark null"}

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,31 @@
 @tailwind utilities;
 
 
+
+@layer base {
+  :root {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 224.3 76.3% 48%;
+  }
+}
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
I've created a right sidebar to encapsulate all action buttons. The sidebar includes the Approve and Delete buttons, as well as information about the current image and annotations. The buttons were removed from the canvas area and positioned vertically in the new sidebar for better organization.